### PR TITLE
Fix CI on Julia non-master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ test:v1.0:
       CI_VERSION_TAG: 'v1.0'
   tags:
       - rocm
-  allow_failure: true
 
 test:v1.1:
   extends: .test

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -66,10 +66,10 @@ world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 # slow lookup of local method age
 function method_age(f, tt)::UInt
     for m in Base._methods(f, tt, 1, typemax(UInt))
-        @static if :min_world in fieldnames(Core.Method)
-            return m[3].min_world
-        else
+        @static if VERSION >= v"1.2.0-DEV.573"
             return m[3].primary_world
+        else
+            return m[3].min_world
         end
     end
     throw(MethodError(f, tt))

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -66,7 +66,11 @@ world_age() = ccall(:jl_get_tls_world_age, UInt, ())
 # slow lookup of local method age
 function method_age(f, tt)::UInt
     for m in Base._methods(f, tt, 1, typemax(UInt))
-        return m[3].min_world
+        @static if :min_world in fieldnames(Core.Method)
+            return m[3].min_world
+        else
+            return m[3].primary_world
+        end
     end
     throw(MethodError(f, tt))
 end


### PR DESCRIPTION
Julia master changed the field `min_world` to `primary_world` in `Core.Method`, so now we handle both cases.