### PR TITLE
LLVM addrspaces fixes and misc. changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/src/compiler/mcgen.jl
+++ b/src/compiler/mcgen.jl
@@ -7,7 +7,7 @@ function machine(agent::HSAAgent, triple::String)
 
     InitializeAMDGPUTargetMC()
     cpu = get_first_isa(agent) # TODO: Make this configurable
-    feat = "+xnack" # TODO: Make this configurable
+    feat = ""
     tm = TargetMachine(t, triple, cpu, feat)
     asm_verbosity!(tm, true)
 

--- a/src/device/tools.jl
+++ b/src/device/tools.jl
@@ -1,6 +1,17 @@
 # Tools for implementing device functionality
 
-# the inverse, ie. which Julia types map a given LLVM types
+# which Julia types map to a given LLVM type
+const llvmtypes = Dict{Type,Symbol}(
+    Nothing => :void,
+    Int8    => :i8,
+    Int16   => :i16,
+    Int32   => :i32,
+    Int64   => :i64,
+    Float32 => :float,
+    Float64 => :double,
+)
+
+# which LLVM types map to a given Julia type
 const jltypes = Dict{Symbol,Type}(
     :void   => Nothing,
     :i8     => Int8,

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -43,7 +43,7 @@ function code_llvm(io::IO, ctx::CompilerContext; optimize::Bool=true,
         entry = optimize!(ctx, mod, entry)
     end
     if strip_ir_metadata
-        #strip_debuginfo!(mod)
+        strip_debuginfo!(mod)
     end
     if dump_module
         show(io, mod)
@@ -78,7 +78,7 @@ function code_gcn(io::IO, ctx::CompilerContext; strip_ir_metadata::Bool=true)
     mod, entry = irgen(ctx)
     entry = optimize!(ctx, mod, entry)
     if strip_ir_metadata
-        #strip_debuginfo!(mod)
+        strip_debuginfo!(mod)
     end
     prepare_execution!(ctx, mod)
     gcn = mcgen(ctx, mod, entry; file_type=LLVM.API.LLVMAssemblyFile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,9 @@ using Test
 
 const DEBUG = get(ENV, "AMDGPUNATIVE_DEBUG", false) == "1"
 
-# Set our default agent to the first GPU available
-HSARuntime.set_default_agent!(:gpu)
 agent_name = HSARuntime.get_name(get_default_agent())
 agent_isa = get_first_isa(get_default_agent())
-@info "Testing using device $name with ISA $agent_isa"
+@info "Testing using device $agent_name with ISA $agent_isa"
 
 @testset "AMDGPUnative" begin
 


### PR DESCRIPTION
Fix AMDGPU addrspace definitions
Make AMDGPU addrspace definitions conditional on LLVM version
Re-enable TBAA
Re-enable strip_debuginfo in reflection's code_llvm and code_gcn
Remove unnecessary set_default_agent! call in tests
Add some more useful mappings to tools.jl
Add Manifest to gitignore
Remove XNACK for now (HSA doesn't like it as-is anymore?)