### PR TITLE
Bump to v0.1.0, UB to HSARuntime v0.2.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,10 @@
 name = "AMDGPUnative"
 uuid = "12f4821f-d7ee-5ba6-b76b-566925c5fcc5"
-version = "0.0.1"
+version = "0.1.0"
+
+[compat]
+julia = "1"
+HSARuntime = "0.2.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Hopefully this will also fix the test failures on Julia 1.0