### PR TITLE
Add workitem/workgroup dimension indexing

### DIFF
--- a/test/device/indexing.jl
+++ b/test/device/indexing.jl
@@ -1,0 +1,39 @@
+@testset "Kernel Indexing" begin
+
+function idx_kern(X)
+    X[1] = AMDGPUnative.workitemIdx_x()
+    X[2] = AMDGPUnative.workitemIdx_y()
+    X[3] = AMDGPUnative.workitemIdx_z()
+
+    X[4] = AMDGPUnative.workgroupIdx_x()
+    X[5] = AMDGPUnative.workgroupIdx_y()
+    X[6] = AMDGPUnative.workgroupIdx_z()
+
+    nothing
+end
+
+A = zeros(Int64, 6)
+HA = HSAArray(A)
+@roc groupsize=(1,2,3) gridsize=(4,5,6) idx_kern(HA)
+A = Array(HA)
+@test all(A .> 0)
+
+function dim_kern(X)
+    X[1] = AMDGPUnative.workitemDim_x()
+    X[2] = AMDGPUnative.workitemDim_y()
+    X[3] = AMDGPUnative.workitemDim_z()
+
+    X[4] = AMDGPUnative.workgroupDim_x()
+    X[5] = AMDGPUnative.workgroupDim_y()
+    X[6] = AMDGPUnative.workgroupDim_z()
+
+    nothing
+end
+
+A = zeros(Int64, 6)
+HA = HSAArray(A)
+@roc groupsize=(1,2,3) gridsize=(4,5,6) dim_kern(HA)
+A = Array(HA)
+@test A ≈ [1,2,3,4,5,6]
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,19 +68,15 @@ if AMDGPUnative.configured
         end
 
         @testset "Device" begin
-        include("device/synchronization.jl")
-        include("device/memory.jl")
-        if Base.libllvm_version >= v"7.0"
-            include("device/math.jl")
-        else
-            @warn "Testing with LLVM 6; some tests will be disabled!"
-            @test_skip "Math Intrinsics"
-        end
-        #include("device/codegen.jl")
-        #include("device/execution.jl")
-        #include("device/pointer.jl")
-        #include("device/array.jl")
-        #include("device/intrinsics.jl")
+            include("device/synchronization.jl")
+            include("device/memory.jl")
+            include("device/indexing.jl")
+            if Base.libllvm_version >= v"7.0"
+                include("device/math.jl")
+            else
+                @warn "Testing with LLVM 6; some tests will be disabled!"
+                @test_skip "Math Intrinsics"
+            end
         end
     end
 else


### PR DESCRIPTION
Todo:
- [x] Validate dimension sizes are correct in tests
- [x] Calculate offset into dispatch packet from `HSARuntime.hsa_kernel_dispatch_packet_t`
- [x] Fix dimension indexing on LLVM 6 (differences in addrspaces and return types)
- [x] Add functions for compat with CUDAnative