### PR TITLE
[WIP] Re-enable ROCDeviceArray boundschecking and fix errors in kernels

### DIFF
--- a/src/AMDGPUnative.jl
+++ b/src/AMDGPUnative.jl
@@ -31,6 +31,7 @@ include(joinpath("device", "pointer.jl"))
 include(joinpath("device", "array.jl"))
 include(joinpath("device", "gcn.jl"))
 include(joinpath("device", "runtime.jl"))
+include(joinpath("device", "llvm.jl"))
 
 include("execution_utils.jl")
 include("compiler.jl")

--- a/src/compiler/irgen.jl
+++ b/src/compiler/irgen.jl
@@ -337,6 +337,7 @@ function emit_exception!(builder, name, inst)
     fun = LLVM.parent(bb)
     mod = LLVM.parent(fun)
 
+    #= FIXME
     # report the exception
     if Base.JLOptions().debug_level >= 1
         name = globalstring_ptr!(builder, name, "exception")
@@ -362,6 +363,7 @@ function emit_exception!(builder, name, inst)
 
     # signal the exception
     call!(builder, Runtime.get(:signal_exception))
+    =#
 
     trap = if haskey(functions(mod), "llvm.trap")
         functions(mod)["llvm.trap"]

--- a/src/device/array.jl
+++ b/src/device/array.jl
@@ -63,20 +63,26 @@ Base.length(g::ROCDeviceArray) = prod(g.shape)
 Base.unsafe_convert(::Type{DevicePtr{T,A}}, a::ROCDeviceArray{T,N,A}) where {T,A,N} = pointer(a)
 
 # indexing
-# FIXME: Boundschecking
 
+# TODO: For some reason, checkbounds(A, index) causes (incorrect?) errors
 @inline function Base.getindex(A::ROCDeviceArray{T}, index::Integer) where {T}
-    #@boundscheck checkbounds(A, index)
+    @boundscheck if !checkbounds(Bool, A, index)
+        trap()
+    end
     align = datatype_align(T)
     Base.unsafe_load(pointer(A), index, Val(align))::T
 end
 
 @inline function Base.setindex!(A::ROCDeviceArray{T}, x, index::Integer) where {T}
-    #@boundscheck checkbounds(A, index)
+    @boundscheck if !checkbounds(Bool, A, index)
+        trap()
+    end
     align = datatype_align(T)
     Base.unsafe_store!(pointer(A), x, index, Val(align))
     return A
 end
+
+Base.IndexStyle(::Type{<:ROCDeviceArray}) = Base.IndexLinear()
 
 # other
 


### PR DESCRIPTION
Use different checkbounds method to prevent odd errors
Disable advanced error reporting for now
Include device/llvm.jl for trap intrinsics