### PR TITLE
Re-enable math intrinsics

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ if AMDGPUnative.configured
             include("device/hostcall.jl")
             include("device/output.jl")
             if Base.libllvm_version >= v"7.0"
-                @test_skip include("device/math.jl")
+                include("device/math.jl")
             else
                 @warn "Testing with LLVM 6; some tests will be disabled!"
                 @test_skip "Math Intrinsics"


### PR DESCRIPTION
No idea why these have decided to start working again (at least they do locally on 1.5), but I'm not going to complain :smile: 

Closes #42 