### PR TITLE
Support emitting user-specified globals

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -49,15 +49,17 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "8d107937ab16bb23e03efe62af954e46d3cfdc80"
-repo-rev = "c10a45eb1c78e261e1e96efc8f6afa9c4999adeb"
+git-tree-sha1 = "3f405c2aab2ef755d022bd57466a35c6d08a1531"
+repo-rev = "158cd601fc42faed088785a7bde16436cbaa6017"
 repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.3.0"
 
 [[HSARuntime]]
 deps = ["CEnum", "Libdl", "Setfield"]
-git-tree-sha1 = "16887a3baae86ebccebcd47c2a2328c96a12fd30"
+git-tree-sha1 = "2e6455b1bcb36471aadfaab4cdeb83a8b3e2cf51"
+repo-rev = "master"
+repo-url = "https://github.com/jpsamaroo/HSARuntime.jl.git"
 uuid = "2c364e2c-59fb-59c3-96f3-194112e690e0"
 version = "0.3.0"
 
@@ -67,9 +69,11 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LLVM]]
 deps = ["CEnum", "Libdl", "Printf", "Unicode"]
-git-tree-sha1 = "93d2e1e960fe47db1a9015e86fad1d47cf67cf59"
+git-tree-sha1 = "dd3f584c3dbefe39b2a8fbafa1a3b77e31e21255"
+repo-rev = "master"
+repo-url = "https://github.com/maleadt/LLVM.jl.git"
 uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
-version = "1.4.1"
+version = "1.5.1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AMDGPUnative"
 uuid = "12f4821f-d7ee-5ba6-b76b-566925c5fcc5"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,12 @@
 using Documenter, AMDGPUnative
 
 makedocs(
-	sitename="AMDGPUnative.jl",
-	pages = [
-		"Home" => "index.md",
-		"Quick Start" => "quickstart.md",
-		"API Reference" => "api.md"
-	]
+    sitename="AMDGPUnative.jl",
+    pages = [
+        "Home" => "index.md",
+        "Quick Start" => "quickstart.md",
+        "Global Variables" => "globals.md",
+        "API Reference" => "api.md"
+    ]
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -39,3 +39,14 @@ blockDim
 sync_workgroup
 ```
 
+### Pointers
+
+```@docs
+AMDGPUnative.DevicePtr
+```
+
+### Global Variables
+
+```@docs
+AMDGPUnative.get_global_pointer
+```

--- a/docs/src/globals.md
+++ b/docs/src/globals.md
@@ -1,0 +1,80 @@
+# Global Variables
+
+Most programmers are familiar with the concept of a "global variable": a
+variable which is globally accessible to any function in the user's program. In
+Julia, programmers are told to avoid using global variables (also known as
+"globals") because of their tendency to introduce type instabilities. However,
+they're often useful for sharing data between functions in distinct areas of
+the user's program.
+
+In the JuliaGPU ecosystem, globals in the Julia sense are not available unless
+their value is constant and inlinable into the function referencing them, as
+all GPU kernels must be statically compileable. However, a different sort of
+global variable is available which serves a very similar purpose. This variant
+of global variable is statically typed and sized, and is accessible from: all
+kernels with the same function signature (e.g. `mykernel(a::Int32,
+b::Float64)`), the CPU host, and other devices and kernels when accessed by
+pointer.
+
+Global variables can be created within kernels with the
+[`AMDGPUnative.get_global_pointer`](@ref) function, which both declares the
+global variable, and returns a pointer to it (specifically a
+[`AMDGPUnative.DevicePtr`](@ref)). Once a kernel which declares a global is
+compiled for GPU execution (either by [`@roc`](@ref) or [`rocfunction`](@ref)),
+the global is allocated memory and made available to the kernel (during the
+linking stage). Globals are unique by name, and so you shouldn't attempt to
+call `get_global_pointer` with the same name but a different type; if you do,
+undefined behavior will result. Like regular pointers in Julia, you can use
+functions like `Base.unsafe_load` and `Base.unsafe_store!` to read from and
+write to the global variable, respectively.
+
+As a concrete example of global variable usage, let's define a kernel which
+creates a global and uses its value to increment the indices of an array:
+
+```julia
+function my_kernel(A)
+    idx = workitemIdx().x
+    ptr = AMDGPUnative.get_global_pointer(Val(:myglobal), Int64)
+    A[idx] += Base.unsafe_load(ptr)
+    nothing
+end
+```
+
+Now, let's compile this kernel and get a pointer to this newly-declared global
+variable. We'll also create an `HSAArray` that we intend to pass to the kernel:
+
+```julia
+HA = HSAArray(ones(Float32, 4))
+kern = rocfunction(my_kernel, Tuple{typeof(rocconvert(HA))})
+gbl = HSARuntime.get_global(kern.mod.exe, :myglobal)
+gbl_ptr = Base.unsafe_convert(Ptr{Int64}, gbl.ptr)
+```
+
+And now `gbl_ptr` is a pointer (specifically a `Ptr{Int64}`) to the memory that
+represents the global variable `myglobal`. We can't guarantee the initial value
+of a newly-initialized global variable, so let's write a value to that global
+variable and then read it back:
+
+```julia
+Base.unsafe_store!(gbl_ptr, 42)
+println(Base.unsafe_load(gbl_ptr))
+```
+
+And now `myglobal` has the value 42, of type `Int64`. Now, let's invoke the
+kernel with `@roc` (keeping in mind that the kernel's signature must be the
+same as in our call to `rocfunction` above:
+
+```julia
+wait(@roc groupsize=4 my_kernel(HA))
+```
+
+We can then read the values of `HA` and see that it's what we expect:
+
+```julia-repl
+julia> A = Array(HA)
+4-element HSAArray{Float32,1}:
+ 43.0
+ 43.0
+ 43.0
+ 43.0
+```

--- a/src/AMDGPUnative.jl
+++ b/src/AMDGPUnative.jl
@@ -32,6 +32,7 @@ include(joinpath("device", "array.jl"))
 include(joinpath("device", "gcn.jl"))
 include(joinpath("device", "runtime.jl"))
 include(joinpath("device", "llvm.jl"))
+include(joinpath("device", "globals.jl"))
 
 include("compiler.jl")
 include("execution_utils.jl")

--- a/src/device/globals.jl
+++ b/src/device/globals.jl
@@ -1,0 +1,42 @@
+# copied from CUDAnative PR 422
+
+# Gets a pointer to a global with a particular name. If the global
+# does not exist yet, then it is declared in the global memory address
+# space.
+@generated function get_global_pointer(::Val{global_name}, ::Type{T})::AMDGPUnative.DevicePtr{T} where {global_name, T}
+    T_global = convert(LLVMType, T)
+    T_result = convert(LLVMType, Ptr{T})
+
+    # Create a thunk that computes a pointer to the global.
+    llvm_f, _ = create_function(T_result)
+    mod = LLVM.parent(llvm_f)
+
+    # Figure out if the global has been defined already.
+    global_set = LLVM.globals(mod)
+    global_name_string = String(global_name)
+    if haskey(global_set, global_name_string)
+        global_var = global_set[global_name_string]
+    else
+        # If the global hasn't been defined already, then we'll define
+        # it in the global address space, i.e., address space one.
+        global_var = GlobalVariable(mod, T_global, global_name_string, 1)
+        linkage!(global_var, LLVM.API.LLVMExternalLinkage)
+        extinit!(global_var, true)
+        set_used!(mod, global_var)
+    end
+
+    # Generate IR that computes the global's address.
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        # Cast the global variable's type to the result type.
+        result = ptrtoint!(builder, global_var, T_result)
+        ret!(builder, result)
+    end
+
+    # Call the function.
+    quote
+        AMDGPUnative.DevicePtr{T, AMDGPUnative.AS.Global}(convert(Csize_t, $(call_function(llvm_f, Ptr{T}))))
+    end
+end

--- a/src/device/tools.jl
+++ b/src/device/tools.jl
@@ -328,3 +328,11 @@ end
     return ex
 end
 
+# calculate the size of an LLVM type
+llvmsize(::LLVM.LLVMHalf) = sizeof(Float16)
+llvmsize(::LLVM.LLVMFloat) = sizeof(Float32)
+llvmsize(::LLVM.LLVMDouble) = sizeof(Float64)
+llvmsize(::LLVM.IntegerType) = div(Int(intwidth(GenericValue(LLVM.Int128Type(), -1))), 8)
+llvmsize(ty::LLVM.ArrayType) = length*llvmsize(eltype(ty))
+# TODO: VectorType, StructType, PointerType
+llvmsize(ty) = error("Unknown size for type: $ty, typeof: $(typeof(ty))")

--- a/test/device/globals.jl
+++ b/test/device/globals.jl
@@ -1,0 +1,20 @@
+@testset "Globals" begin
+
+function kernel(X)
+    ptr = AMDGPUnative.get_global_pointer(Val(:myglobal), Float32)
+    Base.unsafe_store!(ptr, 3f0)
+    nothing
+end
+
+hk = AMDGPUnative.rocfunction(kernel, Tuple{Int32})
+gbl = HSARuntime.get_global(hk.mod.exe, :myglobal)
+gbl_ptr = Base.unsafe_convert(Ptr{Float32}, gbl.ptr)
+
+@test Base.unsafe_load(gbl_ptr) == 0f0
+Base.unsafe_store!(gbl_ptr, 2f0)
+@test Base.unsafe_load(gbl_ptr) == 2f0
+
+wait(@roc groupsize=1 kernel(Int32(1)))
+@test Base.unsafe_load(gbl_ptr) == 3f0
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ if AMDGPUnative.configured
             include("device/indexing.jl")
             include("device/hostcall.jl")
             include("device/output.jl")
+            include("device/globals.jl")
             if Base.libllvm_version >= v"7.0"
                 include("device/math.jl")
             else


### PR DESCRIPTION
This will be the basis for providing a better exception mechanism than `s_trap 2`, but is also general enough for various usecases.

Todo:
- [x] ~Wait for and~ Adapt to https://github.com/JuliaGPU/GPUCompiler.jl/pull/39
- [x] Propagate globals to `create_executable`
- [x] Add tests
- [x] Update docs with instructions for accessing/manipulating globals