### PR TITLE
Implement decent kernel exceptions

### DIFF
--- a/src/device/gcn.jl
+++ b/src/device/gcn.jl
@@ -1,6 +1,4 @@
-if Base.libllvm_version >= v"7.0"
-    include(joinpath("gcn", "math.jl"))
-end
+include(joinpath("gcn", "math.jl"))
 include(joinpath("gcn", "indexing.jl"))
 include(joinpath("gcn", "assertion.jl"))
 include(joinpath("gcn", "synchronization.jl"))

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -33,7 +33,7 @@ end
 @generated function _dim(::Val{base}, ::Val{off}, ::Val{range}, ::Type{T}) where {base, off, range, T}
     T_int8 = LLVM.Int8Type(JuliaContext())
     T_int32 = LLVM.Int32Type(JuliaContext())
-    _as = Base.libllvm_version < v"7.0" ? 2 : 4
+    _as = convert(Int, AS.Constant)
     T_ptr_i8 = LLVM.PointerType(T_int8, _as)
     T_ptr_i32 = LLVM.PointerType(T_int32, _as)
     T_ptr_T = LLVM.PointerType(convert(LLVMType, T), _as)

--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -91,23 +91,13 @@ Base.:(+)(x::Integer, y::DevicePtr) = y + x
 
 # memory operations
 
-@static if Base.libllvm_version < v"7.0"
-    # Old values (LLVM 6)
-    Base.convert(::Type{Int}, ::Type{AS.Private})  = 0
-    Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
-    Base.convert(::Type{Int}, ::Type{AS.Constant}) = 2
-    Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
-    Base.convert(::Type{Int}, ::Type{AS.Generic})  = 4
-    Base.convert(::Type{Int}, ::Type{AS.Region})   = 5
-else
-    # New values (LLVM 7+)
-    Base.convert(::Type{Int}, ::Type{AS.Generic})  = 0
-    Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
-    Base.convert(::Type{Int}, ::Type{AS.Region})   = 2
-    Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
-    Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
-    Base.convert(::Type{Int}, ::Type{AS.Private})  = 5
-end
+# New values (LLVM 7+)
+Base.convert(::Type{Int}, ::Type{AS.Generic})  = 0
+Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
+Base.convert(::Type{Int}, ::Type{AS.Region})   = 2
+Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
+Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
+Base.convert(::Type{Int}, ::Type{AS.Private})  = 5
 
 function tbaa_make_child(name::String, constant::Bool=false; ctx::LLVM.Context=JuliaContext())
     tbaa_root = MDNode([MDString("roctbaa", ctx)], ctx)

--- a/src/device/tools.jl
+++ b/src/device/tools.jl
@@ -333,6 +333,6 @@ llvmsize(::LLVM.LLVMHalf) = sizeof(Float16)
 llvmsize(::LLVM.LLVMFloat) = sizeof(Float32)
 llvmsize(::LLVM.LLVMDouble) = sizeof(Float64)
 llvmsize(::LLVM.IntegerType) = div(Int(intwidth(GenericValue(LLVM.Int128Type(), -1))), 8)
-llvmsize(ty::LLVM.ArrayType) = length*llvmsize(eltype(ty))
+llvmsize(ty::LLVM.ArrayType) = length(ty)*llvmsize(eltype(ty))
 # TODO: VectorType, StructType, PointerType
 llvmsize(ty) = error("Unknown size for type: $ty, typeof: $(typeof(ty))")

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -346,6 +346,15 @@ function _rocfunction(source::FunctionSpec; device=default_device(), queue=defau
     fun = ROCFunction(mod, kernel_fn)
     kernel = HostKernel{source.f,source.tt}(mod, fun)
 
+    # initialize global output context
+    global_oc = findfirst(x->x[1]==:__global_output_context, globals)
+    if global_oc !== nothing
+        gbl = HSARuntime.get_global(exe, :__global_output_context)
+        gbl_ptr = Base.unsafe_convert(Ptr{GLOBAL_OUTPUT_CONTEXT_TYPE}, gbl)
+        oc = OutputContext(stdout)
+        Base.unsafe_store!(gbl_ptr, oc)
+    end
+
     #create_exceptions!(mod)
 
     return kernel

--- a/test/device/output.jl
+++ b/test/device/output.jl
@@ -40,6 +40,17 @@ end
     @test String(take!(iob)) == "Hello World!Goodbye World!\n"
 end
 
+@testset "Plain, global context" begin
+    function kernel(x)
+        @rocprint "Hello World!"
+        @rocprintln "Goodbye World!"
+        nothing
+    end
+
+    _, msg = @grab_output wait(@roc kernel(1))
+    @test msg == "Hello World!Goodbye World!\n"
+end
+
 #= TODO
 @testset "Interpolated string" begin
     inner_str = "to the"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ agent_name = HSARuntime.get_name(get_default_agent())
 agent_isa = get_first_isa(get_default_agent())
 @info "Testing using device $agent_name with ISA $agent_isa"
 
+include("util.jl")
+
 @testset "AMDGPUnative" begin
 
 @testset "Core" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,12 +30,7 @@ if AMDGPUnative.configured
             include("device/hostcall.jl")
             include("device/output.jl")
             include("device/globals.jl")
-            if Base.libllvm_version >= v"7.0"
-                include("device/math.jl")
-            else
-                @warn "Testing with LLVM 6; some tests will be disabled!"
-                @test_skip "Math Intrinsics"
-            end
+            include("device/math.jl")
         end
     end
 else

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,14 @@
+# NOTE: based on test/pkg.jl::capture_stdout, but doesn't discard exceptions
+macro grab_output(ex)
+    quote
+        mktemp() do fname, fout
+            ret = nothing
+            open(fname, "w") do fout
+                redirect_stdout(fout) do
+                    ret = $(esc(ex))
+                end
+            end
+            ret, read(fname, String)
+        end
+    end
+end


### PR DESCRIPTION
Currently, Julia exceptions trigger an `s_trap 2`, which causes the `wait` handler to hang, and doesn't communicate any useful information about what caused the exception. This PR replaces that mechanism with a similar mechanism to the one CUDAnative uses, but with the goal to provide proper per-kernel exceptions (as opposed to throwing the exception at the next API call).